### PR TITLE
Add error message and hint to '+' characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ncbi-entrez-error-messages
+
 A collection of error messages returned by NCBI Entrez
 
 ## Commonly asked questions
@@ -18,6 +19,15 @@ That would all be fine if the error message was consistent, but unfortunately it
 So here is a collection of all the different error messages I have seen from the NCBI
 Entrez API.
 
+### How to check against an error message?
+
+Often the actual sent error message from NCBI contains `'+'` characters instead of whitespace.
+Hence, both `'+'` and whitespace should be removed.
+A check could be done similar to the following Python code:
+```python
+if reference_message.replace(" ", "") in message_from_ncbi.replace("+", "").replace(" ", ""):
+    pass # Do some error handling
+```
 ### Shouldn't such a list be maintained by the NCBI
 
 Yes, but I'm not aware of any NCBI documentation listing the possible error messages.
@@ -27,6 +37,7 @@ Yes, but I'm not aware of any NCBI documentation listing the possible error mess
 Please feel free to open an issue or submit a pull request to add the new message.
 
 ## License
+
 I've added the Apache License to have a license on the repository.
 For all I care, this license only applies to the README and FAQ.
 The error_messages.txt file is a plain data collection that I make

--- a/error_messages.txt
+++ b/error_messages.txt
@@ -6,6 +6,7 @@ server is temporarily unable to service your request
 Service unavailable
 Server Error
 ID list is empty
+Supplied id parameter is empty
 Resource temporarily unavailable
 Failed to retrieve sequence
 Failed to understand id


### PR DESCRIPTION
This PR adds a new error message.
Furthermore, I recently obtained error messages such as
`+Error%3A+CEFetchPApplication%3A%3Aproxy_stream()%3A+F+a+i+l+e+d++t+o++u+n+d+e+r+s+t+a+n+d++i+d+%3A++x+x+x+x+%0A%0A`
 or
`Supplied+id+parameter+is+empty.`
hinting that whitespace characters are replaced by `+`. I added a hint to this in the README